### PR TITLE
Improve dashboard action error handling

### DIFF
--- a/apps/web/app/api/interactions/[id]/status/route.ts
+++ b/apps/web/app/api/interactions/[id]/status/route.ts
@@ -36,5 +36,5 @@ export async function POST(request: Request, { params }: { params: { id: string 
     await runGithubWriteSkillForInteraction({ interactionId: params.id });
   }
 
-  return NextResponse.redirect(new URL(`/dashboard/interactions/${params.id}`, request.url), { status: 303 });
+  return NextResponse.json({ ok: true, status: parsedStatus.data });
 }

--- a/apps/web/components/dashboard/interaction-actions.tsx
+++ b/apps/web/components/dashboard/interaction-actions.tsx
@@ -3,6 +3,8 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 
+import { fetchJson, toUserErrorMessage } from "@/lib/fetch-json";
+
 type InteractionAction = {
   status: "approved" | "needs_review" | "archived";
   label: string;
@@ -41,19 +43,14 @@ export function InteractionActions({ interactionId, actions }: InteractionAction
     formData.set("status", status);
 
     try {
-      const response = await fetch(`/api/interactions/${interactionId}/status`, {
+      await fetchJson(`/api/interactions/${interactionId}/status`, {
         method: "POST",
         body: formData
       });
 
-      if (!response.ok) {
-        throw new Error(`Status update failed (${response.status})`);
-      }
-
       router.refresh();
     } catch (cause) {
-      const message = cause instanceof Error ? cause.message : "Failed to update interaction status.";
-      setError(message);
+      setError(toUserErrorMessage(cause, "Failed to update interaction status."));
     } finally {
       setPendingStatus(null);
     }

--- a/apps/web/components/dashboard/repo-override-form.tsx
+++ b/apps/web/components/dashboard/repo-override-form.tsx
@@ -4,6 +4,8 @@ import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useRef } from "react";
 
+import { fetchJson, toUserErrorMessage } from "@/lib/fetch-json";
+
 type RepoOverrideFormProps = {
   interactionId: string;
   currentRepoName: string;
@@ -52,18 +54,15 @@ export function RepoOverrideForm(props: RepoOverrideFormProps) {
           params.set("owners", props.owners.join(","));
         }
 
-        const response = await fetch(`/api/github/repositories/suggest?${params.toString()}`, {
+        const data = await fetchJson<{ repoNames?: string[] }>(`/api/github/repositories/suggest?${params.toString()}`, {
           signal: controller.signal
         });
-
-        if (!response.ok) {
-          setRemoteSuggestions([]);
+        setRemoteSuggestions(data.repoNames ?? []);
+      } catch (error) {
+        if (error instanceof DOMException && error.name === "AbortError") {
           return;
         }
 
-        const data = (await response.json()) as { repoNames?: string[] };
-        setRemoteSuggestions(data.repoNames ?? []);
-      } catch {
         setRemoteSuggestions([]);
       } finally {
         setLoading(false);
@@ -93,6 +92,10 @@ export function RepoOverrideForm(props: RepoOverrideFormProps) {
 
   async function onSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
+    if (saving) {
+      return;
+    }
+
     setSaving(true);
     setToastError(null);
 
@@ -100,16 +103,10 @@ export function RepoOverrideForm(props: RepoOverrideFormProps) {
       const body = new FormData();
       body.set("repoName", value);
 
-      const response = await fetch(`/api/interactions/${props.interactionId}/repo`, {
+      await fetchJson(`/api/interactions/${props.interactionId}/repo`, {
         method: "POST",
         body
       });
-
-      if (!response.ok) {
-        const data = (await response.json().catch(() => ({}))) as { error?: string };
-        setToastError(data.error || "Failed to update repository.");
-        return;
-      }
 
       const container = rootRef.current?.closest("details");
       if (container instanceof HTMLDetailsElement) {
@@ -117,8 +114,8 @@ export function RepoOverrideForm(props: RepoOverrideFormProps) {
       }
 
       router.refresh();
-    } catch {
-      setToastError("Network error while updating repository.");
+    } catch (error) {
+      setToastError(toUserErrorMessage(error, "Network error while updating repository."));
     } finally {
       setSaving(false);
     }

--- a/apps/web/components/dashboard/summary-override-form.tsx
+++ b/apps/web/components/dashboard/summary-override-form.tsx
@@ -3,6 +3,8 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 
+import { fetchJson, toUserErrorMessage } from "@/lib/fetch-json";
+
 type SummaryOverrideFormProps = {
   interactionId: string;
   currentSummary: string;
@@ -18,6 +20,10 @@ export function SummaryOverrideForm(props: SummaryOverrideFormProps) {
 
   async function onSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
+    if (saving) {
+      return;
+    }
+
     setSaving(true);
     setToastError(null);
 
@@ -25,22 +31,16 @@ export function SummaryOverrideForm(props: SummaryOverrideFormProps) {
       const body = new FormData();
       body.set("summary", draftValue);
 
-      const response = await fetch(`/api/interactions/${props.interactionId}/summary`, {
+      await fetchJson(`/api/interactions/${props.interactionId}/summary`, {
         method: "POST",
         body
       });
 
-      if (!response.ok) {
-        const data = (await response.json().catch(() => ({}))) as { error?: string };
-        setToastError(data.error || "Failed to update summary.");
-        return;
-      }
-
       setSavedValue(draftValue);
       setIsEditing(false);
       router.refresh();
-    } catch {
-      setToastError("Network error while updating summary.");
+    } catch (error) {
+      setToastError(toUserErrorMessage(error, "Network error while updating summary."));
     } finally {
       setSaving(false);
     }

--- a/apps/web/lib/fetch-json.ts
+++ b/apps/web/lib/fetch-json.ts
@@ -1,0 +1,46 @@
+"use client";
+
+type ApiErrorPayload = {
+  error?: string;
+};
+
+function isJsonResponse(response: Response) {
+  const contentType = response.headers.get("content-type") ?? "";
+  return contentType.includes("application/json");
+}
+
+async function readErrorMessage(response: Response) {
+  if (isJsonResponse(response)) {
+    const payload = (await response.json().catch(() => null)) as ApiErrorPayload | null;
+    if (payload?.error) {
+      return payload.error;
+    }
+  }
+
+  return `Request failed (${response.status})`;
+}
+
+export async function fetchJson<T>(input: RequestInfo | URL, init: RequestInit = {}) {
+  const response = await fetch(input, {
+    ...init,
+    redirect: init.redirect ?? "error"
+  });
+
+  if (!response.ok) {
+    throw new Error(await readErrorMessage(response));
+  }
+
+  if (!isJsonResponse(response)) {
+    return null as T;
+  }
+
+  return (await response.json()) as T;
+}
+
+export function toUserErrorMessage(error: unknown, fallback: string) {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  return fallback;
+}


### PR DESCRIPTION
## Summary
- add a shared client-side JSON fetch helper that surfaces API error messages consistently
- update dashboard interaction, repo override, and summary override forms to use the helper and guard against duplicate submits
- return JSON from the interaction status API route so client-side status updates do not depend on redirect responses

## Testing
- npm run lint --workspace @walkflow/web
- npm run typecheck --workspace @walkflow/web