### PR TITLE
Fix relay retry summary transcript input

### DIFF
--- a/apps/relay/src/proposal-transcript.test.ts
+++ b/apps/relay/src/proposal-transcript.test.ts
@@ -1,0 +1,32 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { buildProposalTranscript } from "./proposal-transcript";
+
+test("buildProposalTranscript drops control-only retry utterances", () => {
+  const transcript = buildProposalTranscript([
+    "I'd like to open up pull request against workflow test.",
+    "Just that it should be an example of this buzz.",
+    "No. That's it.",
+    "Reject.",
+    "I also want to include tests.",
+    "No. That's it."
+  ]);
+
+  assert.equal(
+    transcript,
+    [
+      "I'd like to open up pull request against workflow test.",
+      "Just that it should be an example of this buzz.",
+      "I also want to include tests."
+    ].join("\n")
+  );
+});
+
+test("buildProposalTranscript keeps corrections attached to rejection phrasing", () => {
+  const transcript = buildProposalTranscript([
+    "Reject. Make it ways to make 100 cents."
+  ]);
+
+  assert.equal(transcript, "Reject. Make it ways to make 100 cents.");
+});

--- a/apps/relay/src/proposal-transcript.ts
+++ b/apps/relay/src/proposal-transcript.ts
@@ -1,0 +1,30 @@
+const CONTROL_ONLY_PATTERNS = [
+  /^(?:reject|no|nope|try again)\.?$/i,
+  /^(?:confirm|approved?|yes|yeah|yep)\.?$/i,
+  /^(?:no(?:[,.]|\s)+)?(?:that'?s all|that is all|that'?s it|nothing else|done|finished|all good)\.?$/i,
+  /^(?:goodbye|bye|hang up)\.?$/i
+];
+
+function normalizeUtterance(value: string) {
+  return value.trim().replace(/\s+/g, " ");
+}
+
+function isControlOnlyUtterance(value: string) {
+  const normalized = normalizeUtterance(value);
+  if (!normalized) {
+    return true;
+  }
+
+  return CONTROL_ONLY_PATTERNS.some((pattern) => pattern.test(normalized));
+}
+
+export function buildProposalTranscript(callerNotes: string[]) {
+  const normalizedNotes = callerNotes
+    .map((note) => normalizeUtterance(note))
+    .filter(Boolean);
+
+  const substantiveNotes = normalizedNotes.filter((note) => !isControlOnlyUtterance(note));
+  const notesForProposal = substantiveNotes.length > 0 ? substantiveNotes : normalizedNotes;
+
+  return notesForProposal.join("\n").trim();
+}

--- a/apps/relay/src/server.ts
+++ b/apps/relay/src/server.ts
@@ -22,6 +22,7 @@ import {
 } from "@walkflow/core/lib/twilio/conversation-relay";
 import { triggerGithubWriteSkillForInteraction } from "@walkflow/core/lib/skills/github-write";
 import { serializeTranscriptTurns, transcriptToPlainText, type TranscriptTurn } from "@walkflow/core/lib/transcript";
+import { buildProposalTranscript } from "./proposal-transcript";
 
 type VoicePhase = "collecting" | "awaiting_confirmation" | "awaiting_retry_context" | "closed";
 
@@ -267,7 +268,7 @@ function resolveRepoOverride(text: string, availableRepos: string[]) {
 }
 
 function plainTextTranscriptForSession(session: SessionState) {
-  return session.callerNotes.join("\n").trim();
+  return buildProposalTranscript(session.callerNotes);
 }
 
 async function failClosedForVoiceAi(ws: WebSocket, session: SessionState, error: unknown) {


### PR DESCRIPTION
## Summary
- filter control-only caller utterances like `Reject.` and `No. That's it.` out of the transcript used for retry proposal generation
- keep substantive correction phrases intact so retry summaries still incorporate the caller's actual change request
- cover the retry transcript builder with focused relay tests

## Context
The latest failing live call reached the first reject path, asked `What should I change?`, captured `I also want to include tests.`, then said `Let me summarize that.` and failed closed before reading a revised summary. This change makes the retry proposal input less brittle by removing control-only turns from the proposal transcript.

## Testing
- node --import tsx --test apps/relay/src/proposal-transcript.test.ts
- npm run typecheck --workspace @walkflow/relay
- npm run typecheck --workspace @walkflow/web